### PR TITLE
Fix monthly resampling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -29,7 +29,10 @@ def simulate(data: SimulateRequest):
     for ticker, amount in zip(data.tickers, data.amounts):
         try:
             df = yf.download(ticker, start=start_date, end=end_date)
-            monthly = df["Close"].resample("ME").first()
+            # pandas uses 'M' for month end frequency. 'ME' is invalid and
+            # triggers an error, resulting in "Error" values in the response.
+            # Use the correct alias so resampling succeeds.
+            monthly = df["Close"].resample("M").first()
 
             if monthly.empty:
                 raise ValueError("no data")


### PR DESCRIPTION
## Summary
- fix resampling frequency in the backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683ff23bdd70832d86596ba1cd03c0b2