### PR TITLE
Add strategy comparison and moving average crossover

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project provides a collection of small tools to explore quantitative finance concepts.
 The main page allows choosing between the following mini projects:
 
-1. **Investment Strategy Simulator** – compare dollar-cost averaging (DCA) and lump-sum investment strategies over the last five years.
+1. **Investment Strategy Simulator** – evaluate dollar-cost averaging (DCA), lump-sum investment, a direct comparison of the two and a simple moving average crossover strategy over the last five years.
 2. **Stock Volatility Comparison** – visualise daily return distributions with simple boxplots.
 
 ## Structure

--- a/frontend/src/Chart.jsx
+++ b/frontend/src/Chart.jsx
@@ -1,13 +1,23 @@
-import { BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid, Legend } from 'recharts'
 
 export default function ResultChart({ data }) {
+  if (!data || data.length === 0) return null
+  const first = data[0]
   return (
     <BarChart width={1000} height={600} data={data}>
       <CartesianGrid strokeDasharray="3 3" />
       <XAxis dataKey="ticker" />
       <YAxis />
       <Tooltip />
-      <Bar dataKey="final_value" fill="#FFFFFF" barSize={20}/>
+      <Legend />
+      {first.final_values ? (
+        <>
+          <Bar dataKey="final_values.monthly" fill="#8884d8" name="Monthly" barSize={20}/>
+          <Bar dataKey="final_values.lump_sum" fill="#82ca9d" name="Lump Sum" barSize={20}/>
+        </>
+      ) : (
+        <Bar dataKey="final_value" fill="#FFFFFF" barSize={20}/>
+      )}
     </BarChart>
   )
 }

--- a/frontend/src/StrategySimulator.jsx
+++ b/frontend/src/StrategySimulator.jsx
@@ -111,6 +111,8 @@ function StrategySimulator({ onBack }) {
         >
           <option value="monthly">Invest Monthly</option>
           <option value="lump_sum">Lump Sum</option>
+          <option value="both">Monthly vs Lump Sum</option>
+          <option value="ma_crossover">Moving Average Crossover</option>
         </select>
 
         <button
@@ -131,22 +133,43 @@ function StrategySimulator({ onBack }) {
 
         {results.length > 0 && (
           <>
-            <table style={{ width: "100%", textAlign: "left", marginTop: "20px" }}>
-              <thead>
-                <tr>
-                  <th>Ticker</th>
-                  <th>Final Value (USD)</th>
-                </tr>
-              </thead>
-              <tbody>
-                {results.map((r) => (
-                  <tr key={r.ticker}>
-                    <td>{r.ticker}</td>
-                    <td>{r.final_value ? `$${r.final_value}` : "Error"}</td>
+            {strategy === "both" ? (
+              <table style={{ width: "100%", textAlign: "left", marginTop: "20px" }}>
+                <thead>
+                  <tr>
+                    <th>Ticker</th>
+                    <th>Monthly (USD)</th>
+                    <th>Lump Sum (USD)</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {results.map((r) => (
+                    <tr key={r.ticker}>
+                      <td>{r.ticker}</td>
+                      <td>{r.final_values ? `$${r.final_values.monthly}` : "Error"}</td>
+                      <td>{r.final_values ? `$${r.final_values.lump_sum}` : "Error"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <table style={{ width: "100%", textAlign: "left", marginTop: "20px" }}>
+                <thead>
+                  <tr>
+                    <th>Ticker</th>
+                    <th>Final Value (USD)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {results.map((r) => (
+                    <tr key={r.ticker}>
+                      <td>{r.ticker}</td>
+                      <td>{r.final_value ? `$${r.final_value}` : "Error"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
 
             <ResultChart data={results} />
             <PriceChart data={priceData} tickers={results.map((r) => r.ticker)} />


### PR DESCRIPTION
## Summary
- support a new `both` strategy to compare monthly vs lump sum performance
- implement moving average crossover simulation in backend
- extend frontend to choose the new strategies
- update charts and table rendering accordingly
- document new functionality in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yfinance')*

------
https://chatgpt.com/codex/tasks/task_e_6848019e46d4832d99dceb908f3de2ec